### PR TITLE
cleaner printing for stat option and print option

### DIFF
--- a/src/FITSexplore.jl
+++ b/src/FITSexplore.jl
@@ -290,9 +290,9 @@ function main(args)
 										println()
 										if plott
 											if ndims(data) ==3
-												display(heatmap(clamp.(mean(data,dims=3)[:,:,1],minn,maxx)))
+												display(heatmap(clamp.(mean(data,dims=3)[:,:,1],minn,maxx)'))
 											else
-												display(heatmap(clamp.(data,minn,maxx)))
+												display(heatmap(clamp.(data,minn,maxx)'))
 											end
 											
 										end
@@ -311,9 +311,9 @@ function main(args)
 										println()
 										if plott
 											if ndims(data) ==3
-												display(heatmap(clamp.(mean(data,dims=3)[:,:,1],minn,maxx)))
+												display(heatmap(clamp.(mean(data,dims=3)[:,:,1],minn,maxx)'))
 											else
-												display(heatmap(clamp.(data,minn,maxx)))
+												display(heatmap(clamp.(data,minn,maxx)'))
 											end
 											
 										end

--- a/src/FITSexplore.jl
+++ b/src/FITSexplore.jl
@@ -163,15 +163,15 @@ function print_stats(a)
 	#           round.(mad(a); digits=4))
 	
 	
-	println("size \t type \t\t mean\tstd\tmedian\tmad")
 	med= median(a)
 	madd= mad(a,center=med)
 	minn =round.(minimum(a); digits=4) 
 	maxx =round.(maximum(a); digits=4) 
-	println(size(a),"\t",eltype(a),"\t \t",
-	round.(mean(a); digits=4)," \t",
-	round.(std(a); digits=4),"\t",round.(med; digits=4),"\t",
-	round.(madd; digits=4))
+	println(
+		"size ", size(a), "  eltype ", eltype(a),
+		"  mean ", round.(mean(a); digits=4), "  std ", round.(std(a); digits=4),
+		"  median ", round.(med; digits=4), "  mad ", round.(madd; digits=4)
+	)
 	try 
 		h = fit(Histogram,a[:], range(max(minn,med-3*madd),min(maxx,med+3*madd),50)) 
 		W = h.weights


### PR DESCRIPTION
What do you think ?

On one line with labels next to values.

Preview:
```
> fe -s FLAT,LAMP_10.004104s_2021-06-19_IMAGE,DUAL_DB_H23_10f_SPHER.2021-06-19T17:17:37.620.fits
FLAT,LAMP_10.004104s_2021-06-19_IMAGE,DUAL_DB_H23_10f_SPHER.2021-06-19T17:17:37.620.fits  hdu :nothing
size (2048, 1024, 10)  eltype Float32  mean 14317.351  std 5951.6406  median 16990.908  mad 928.303
-504.577                ▁▁▁▂▃▄▆███▇▇▇██▇▅▃▁              57362.746
```

And for printing I transpose the image as it is more usual.
