### PR TITLE
optional keywords -K

### DIFF
--- a/src/FITSexplore.jl
+++ b/src/FITSexplore.jl
@@ -103,17 +103,21 @@ function parse_keywords(
 				header  = read_header(filename)
 				str = ""
 				iskeyword = true
+				isfirst = true
 				for key in keywords
 					if haskey(header,key)
-						str = str * "\t" * string(header[key])
+						isfirst || (str *= "\t")
+						str *= string(header[key])
 					else
 						iskeyword = false
 					end
+					isfirst = false
 				end
 				if iskeyword
 					for key in keywordsoptional
-						value = haskey(header,key) ? string(header[key]) : " "
-						str *= "\t" * value
+						isfirst || (str *= "\t")
+						str *= haskey(header,key) ? string(header[key]) : " "
+						isfirst = false
 					end
 					println(filename ,"\t", str)
 				end


### PR DESCRIPTION
Added option -K, similar to -k but if no keyword is found, use the value " " instead.

optional keywords are printed after required keywords, because the args system puts them in different lists.

- a space is used instead of empty string, so it can be distinguished from null fits value, and also it can works better with some formatting of the output.
- optional keywords are put to the end, because the args system puts them in another list.